### PR TITLE
types(watch): allow to accept readonly arrays

### DIFF
--- a/packages/runtime-core/src/apiWatch.ts
+++ b/packages/runtime-core/src/apiWatch.ts
@@ -56,7 +56,7 @@ export function watch<T>(
 ): StopHandle
 
 // overload #3: array of multiple sources + cb
-export function watch<T extends WatcherSource<unknown>[]>(
+export function watch<T extends readonly WatcherSource<unknown>[]>(
   sources: T,
   cb: (
     newValues: MapSources<T>,


### PR DESCRIPTION
This PR updates `watchApi` array type to allow pass readonly arrays. When we mark array as readonly, its length and order of contained types is being preserved, so it allows for better type inference without type checking of each array element. It doesn't break current behaviour and it is allowed to pass non-readonly arrays aswell.

No `const` casting.
We have to check if element is a object or number, since it is an array of any length with these two types:
```ts
const count = ref(0);
const state = reactive({ count: 1 })

watch(
  [() => state, count], // ({ count: number } | number)[]
  ([state, count]) => {
    if (typeof state === 'object') {
      state.count++;
    }
    if (typeof count === 'number') {
      count++;
    }
  }
);
```

With `const` casting.
More type information is being preserved and array has constant length (array became a tuple):
```ts
const count = ref(0);
const state = reactive({ count: 1 })

watch(
  [() => state, count] as const, // [{ count: number }, number]
  ([state, count]) => {
    state.count++;
    count++;
  }
)
```